### PR TITLE
Schedule create and delete 

### DIFF
--- a/Modules/hpe3par_snapshot.py
+++ b/Modules/hpe3par_snapshot.py
@@ -499,8 +499,6 @@ null",
         expirationHours = convert_to_hours(expiration_time, expiration_unit)
         retentionHours = convert_to_hours(retention_time, retention_unit)
         freq = "@hourly"
-        if not client_obj.volumeExists(base_volume_name):
-           return (False, False, "volume not Exist", {})
            
         if not client_obj.scheduleExists(schedule_name):
            cmd = ["createsv"]

--- a/Modules/hpe3par_snapshot.py
+++ b/Modules/hpe3par_snapshot.py
@@ -498,6 +498,7 @@ null",
         client_obj.setSSHOptions(storage_system_ip, storage_system_username, storage_system_password)
         expirationHours = convert_to_hours(expiration_time, expiration_unit)
         retentionHours = convert_to_hours(retention_time, retention_unit)
+        freq = "@hourly"
         if not client_obj.volumeExists(base_volume_name):
            return (False, False, "volume not Exist", {})
            
@@ -505,24 +506,25 @@ null",
            cmd = ["createsv"]
            if read_only:
               cmd.append("-ro")
+           if expirationHours != None:
               cmd.append("-exp")
               cmd.append(str(expirationHours)+"h")
-              if retentionHours != None:
+           if retentionHours != None:
                  cmd.append("-retain")
                  cmd.append(str(retentionHours)+"h")
-              snap_string = ".@y@@m@@d@@H@@M@@S@"
-              cmd.append("snap-"+base_volume_name+snap_string)
-              cmd.append(base_volume_name)
-              if task_freq_custom:
+           snap_string = ".@y@@m@@d@@H@@M@@S@"
+           cmd.append("snap-"+base_volume_name+snap_string)
+           cmd.append(base_volume_name)
+           if task_freq_custom:
                  freq = task_freq_custom
 
-              if task_freq:
+           if task_freq:
                   freq="@"+task_freq
-              cmd = ' '.join(cmd)
-              client_obj.createSchedule(
+           cmd = ' '.join(cmd)
+           client_obj.createSchedule(
                 schedule_name, cmd, freq)
         else:
-            return (True, False, "Schedule not Exist", {})
+            return (True, False, "Schedule Exist", {})
     except Exception as e:
         return (False, "False", "Schedule creation failed | %s" % (e), {})
     finally:

--- a/Modules/hpe3par_snapshot.py
+++ b/Modules/hpe3par_snapshot.py
@@ -498,14 +498,18 @@ null",
         client_obj.setSSHOptions(storage_system_ip, storage_system_username, storage_system_password)
         expirationHours = convert_to_hours(expiration_time, expiration_unit)
         retentionHours = convert_to_hours(retention_time, retention_unit)
+        if not client_obj.volumeExists(base_volume_name):
+           return (False, False, "volume not Exist", {})
+           
         if not client_obj.scheduleExists(schedule_name):
            cmd = ["createsv"]
            if read_only:
               cmd.append("-ro")
               cmd.append("-exp")
-              cmd.append(str(expirationHours))
-              cmd.append("-retain")
-              cmd.append(str(retentionHours))
+              cmd.append(str(expirationHours)+"h")
+              if retentionHours != None:
+                 cmd.append("-retain")
+                 cmd.append(str(retentionHours)+"h")
               snap_string = ".@y@@m@@d@@H@@M@@S@"
               cmd.append("snap-"+base_volume_name+snap_string)
               cmd.append(base_volume_name)

--- a/test/unit/test_hpe3par_snapshot.py
+++ b/test/unit/test_hpe3par_snapshot.py
@@ -649,6 +649,21 @@ null", {}))
                                                           10,
                                                           'Hours',
                                                           'Days',
+                                                          '0 * * * *',''
+                                                          ), (True, True, "Created Schedule %s successfully." % 'test_schedule', {}))
+
+        self.assertEqual(hpe3par_snapshot.create_schedule(mock_client.HPE3ParClient,
+                                                          '192.168.0.1',
+                                                          'USER',
+                                                          'PASS',
+                                                          'test_schedule',
+                                                          'test_snapshot',
+                                                          'base_volume',
+                                                          True,
+                                                          10,
+                                                          10,
+                                                          'Hours',
+                                                          'Days',
                                                           'hourly',''
                                                           ), (True, True, "Created Schedule %s successfully." % 'test_schedule', {}))
 
@@ -728,20 +743,6 @@ null", {}))
                                                           '0 * * * *',''
                                                           ), (False, False, "Schedule create failed. Base volume name is null", {}))
 
-        self.assertEqual(hpe3par_snapshot.create_schedule(mock_client.HPE3ParClient,
-                                                          '192.168.0.1',
-                                                          'USER',
-                                                          'PASS',
-                                                          'test_schedule',
-                                                          'test_snapshot',
-                                                          None,
-                                                          True,
-                                                          10,
-                                                          10,
-                                                          'Hours',
-                                                          'Days',
-                                                          '0 * * * *',''
-                                                          ), (True, True, "Schedule create sucessfully", {}))
 
        
     @mock.patch('Modules.hpe3par_snapshot.client')

--- a/test/unit/test_hpe3par_snapshot.py
+++ b/test/unit/test_hpe3par_snapshot.py
@@ -681,7 +681,7 @@ null", {}))
                                                           'Hours',
                                                           'Days',
                                                           'hourly',''
-                                                          ), (True, False, "Schedule not Exist", {}))
+                                                          ), (True, False, "Schedule Exist", {}))
         
         mock_client.HPE3ParClient.scheduleExists.return_value = True
         self.assertEqual(hpe3par_snapshot.create_schedule(mock_client.HPE3ParClient,

--- a/test/unit/test_hpe3par_snapshot.py
+++ b/test/unit/test_hpe3par_snapshot.py
@@ -727,6 +727,22 @@ null", {}))
                                                           'Days',
                                                           '0 * * * *',''
                                                           ), (False, False, "Schedule create failed. Base volume name is null", {}))
+
+        self.assertEqual(hpe3par_snapshot.create_schedule(mock_client.HPE3ParClient,
+                                                          '192.168.0.1',
+                                                          'USER',
+                                                          'PASS',
+                                                          'test_schedule',
+                                                          'test_snapshot',
+                                                          None,
+                                                          True,
+                                                          10,
+                                                          10,
+                                                          'Hours',
+                                                          'Days',
+                                                          '0 * * * *',''
+                                                          ), (True, True, "Schedule create sucessfully", {}))
+
        
     @mock.patch('Modules.hpe3par_snapshot.client')
     def test_delete_schedule(self, mock_client):


### PR DESCRIPTION
root@cssosbe03-b12:/home/nirun/niru_ansiblecopy/hpe3par_ansible_module# ansible-playbook schedule.yml
 [WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

 [WARNING]: While constructing a mapping from /home/nirun/niru_ansiblecopy/hpe3par_ansible_module/remote_copy.yml, line 3,
column 5, found a duplicate dict key (http_proxy). Using last defined value only.


PLAY [localhost] ************************************************************************************************************

TASK [Gathering Facts] ******************************************************************************************************
ok: [localhost]

TASK [Create Schedule on source] ********************************************************************************************
changed: [localhost]

TASK [pause] ****************************************************************************************************************
[pause]
Press Enter:
ok: [localhost]

TASK [Delete Schedule from source] ******************************************************************************************
changed: [localhost]

PLAY RECAP ******************************************************************************************************************
localhost                  : ok=4    changed=2    unreachable=0    failed=0